### PR TITLE
feat: Folder Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
   **Automatically organize your Replay Buffer clips, Recordings, and Screenshots into game-specific folders.**
 
-  [![Version](https://img.shields.io/badge/version-2.10.0-00d4aa.svg)](https://github.com/SlonickLab/Smart-Replay-Mover/releases)
+  [![Version](https://img.shields.io/badge/version-2.11.0-00d4aa.svg)](https://github.com/SlonickLab/Smart-Replay-Mover/releases)
   [![License](https://img.shields.io/badge/license-GPL%20v3-blue.svg)](LICENSE)
   [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux-0078D6.svg)]()
   [![OBS](https://img.shields.io/badge/OBS-28.x+-302E31.svg)](https://obsproject.com/)
@@ -74,7 +74,7 @@
 
 - **Anti-Spam Protection** — Deletes duplicate files from panic-pressing hotkeys
 - **Case-Insensitive** — Won't create duplicate folders with different cases
-- **Date Subfolders** — Optional monthly organization (2025-06/)
+- **🧩 Folder Templates** — Shape the destination with tokens like `{game}`, `{yearmonth}` and `{date}` (e.g. `{game}/Replays` or `{game}/{yearmonth}`)
 - **230+ Ignored Programs** — Won't confuse Discord, Chrome, launchers or utilities with games
 - **⚡ Smart Save Hotkey** — Instant "Saving..." notification when pressing your custom hotkey
 - **📂 No-Folder Mode** — Map a process to `/`, `\`, or `.` to keep files in OBS output root
@@ -207,10 +207,24 @@
 
   | Setting | Description |
   |---------|-------------|
-  | Monthly subfolders | Creates `YYYY-MM` subfolders |
+  | Folder template | Destination structure built from tokens, relative to the OBS output folder (default `{game}`) |
   | Organize screenshots | Also sort screenshots |
   | Organize recordings | Sort regular recordings (not just replays) |
   | Scan all processes | Detect background games when alt-tabbed (Windows only) |
+
+  **Folder template tokens**
+
+  | Token | Expands to |
+  |-------|------------|
+  | `{game}` | Detected game folder (e.g. `Counter-Strike 2`) |
+  | `{year}` `{month}` `{day}` | `2026` / `07` / `23` |
+  | `{date}` | `2026-07-23` |
+  | `{yearmonth}` | `2026-07` — same as the old monthly subfolders |
+  | `{hour}` `{min}` | Clock time |
+
+  Examples: `{game}/Replays` → `Counter-Strike 2/Replays/` · `{game}/{yearmonth}` → `Counter-Strike 2/2026-07/`. Paths are always relative to the OBS output folder — templates can't escape it.
+
+  > 🔄 **Upgrading from monthly subfolders?** If you had that option enabled, the settings show a one-time **Migrate** button that folds it into your template as `{game}/{yearmonth}`, then disappears. Your existing layout is preserved.
 
 ### 🛡️ Spam Protection
 
@@ -369,7 +383,7 @@
   │   └── Space Marine 2 - 2025-06-17 18-45-00.mp4
   │
   ├── 📁 Minecraft/
-  │   └── 2025-06/                    ← Optional date subfolder
+  │   └── 2025-06/                    ← from a "{game}/{yearmonth}" template
   │       └── Minecraft - 2025-06-18 11-22-33.mp4
   │
   └── 📁 Desktop/                     ← Fallback folder
@@ -488,6 +502,12 @@
   ---
 
 ## 📋 Changelog
+
+### v2.11.0 — 🧩 Folder Templates
+
+- **🧩 Folder Templates** — The destination structure is now a template with tokens instead of a fixed `{game}` folder. Tokens: `{game}`, `{year}`, `{month}`, `{day}`, `{date}`, `{yearmonth}`, `{hour}`, `{min}`. Examples: `{game}/Replays`, `{game}/{yearmonth}`. Resolved relative to the OBS output folder, with every path segment sanitized so a template can never escape it (no absolute paths, no `..` traversal). The default `{game}` reproduces the previous behavior exactly.
+- **🔄 Monthly-Subfolder Migration** — The old "monthly subfolders (YYYY-MM)" checkbox is replaced by the `{yearmonth}` token. If you had it enabled, a one-time **Migrate** button folds it into your template as `{game}/{yearmonth}` and then hides itself — nothing changes silently, and existing folder layouts are preserved.
+- **🧹 Simpler Directory Creation** — Folder creation is now a single recursive `mkdir` that handles arbitrary template depth.
 
 ### v2.10.0 — 🔌 Replay Buffer Pro Compatibility
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 
 - **Anti-Spam Protection** — Deletes duplicate files from panic-pressing hotkeys
 - **Case-Insensitive** — Won't create duplicate folders with different cases
-- **🧩 Folder Templates** — Shape the destination with tokens like `{game}`, `{yearmonth}` and `{date}` (e.g. `{game}/Replays` or `{game}/{yearmonth}`)
+- **🧩 Folder Templates** — Organize into any structure with `{game}`, `{yearmonth}`, `{date}` and more tokens
 - **230+ Ignored Programs** — Won't confuse Discord, Chrome, launchers or utilities with games
 - **⚡ Smart Save Hotkey** — Instant "Saving..." notification when pressing your custom hotkey
 - **📂 No-Folder Mode** — Map a process to `/`, `\`, or `.` to keep files in OBS output root
@@ -203,28 +203,41 @@
   | Mode | Auto-Detect (default — activates only when the plugin is installed), Always On, or Off |
   | Remove "_trimmed" suffix | Renames Replay Buffer Pro's trimmed clip back to a clean name while organizing (on by default) |
 
-### 🗂️ Organization
+### 🧩 Folder Templates
 
-  | Setting | Description |
-  |---------|-------------|
-  | Folder template | Destination structure built from tokens, relative to the OBS output folder (default `{game}`) |
-  | Organize screenshots | Also sort screenshots |
-  | Organize recordings | Sort regular recordings (not just replays) |
-  | Scan all processes | Detect background games when alt-tabbed (Windows only) |
-
-  **Folder template tokens**
+  The destination folder is a **template** of `{tokens}`, resolved when each clip is saved. The default `{game}` reproduces the classic per-game layout.
 
   | Token | Expands to |
   |-------|------------|
   | `{game}` | Detected game folder (e.g. `Counter-Strike 2`) |
   | `{year}` `{month}` `{day}` | `2026` / `07` / `23` |
   | `{date}` | `2026-07-23` |
-  | `{yearmonth}` | `2026-07` — same as the old monthly subfolders |
+  | `{yearmonth}` | `2026-07` (the old monthly-subfolder format) |
   | `{hour}` `{min}` | Clock time |
 
-  Examples: `{game}/Replays` → `Counter-Strike 2/Replays/` · `{game}/{yearmonth}` → `Counter-Strike 2/2026-07/`. Paths are always relative to the OBS output folder — templates can't escape it.
+  **Examples**
 
-  > 🔄 **Upgrading from monthly subfolders?** If you had that option enabled, the settings show a one-time **Migrate** button that folds it into your template as `{game}/{yearmonth}`, then disappears. Your existing layout is preserved.
+  | Template | Result |
+  |----------|--------|
+  | `{game}` | `Counter-Strike 2/` |
+  | `{game}/Replays` | `Counter-Strike 2/Replays/` |
+  | `{game}/{yearmonth}` | `Counter-Strike 2/2026-07/` |
+  | `{yearmonth}/{game}` | `2026-07/Counter-Strike 2/` |
+  | `{game}/{year} - {hour} - {min}` | `Counter-Strike 2/2026 - 18 - 53/` |
+
+  Combine tokens in one folder with any separator you like. Only `/` starts a new subfolder, so `{hour} - {min}` becomes `18 - 53` and `{game}/{year} - {hour} - {min}` becomes `Counter-Strike 2/2026 - 18 - 53/`.
+
+  The template is always resolved **relative to the OBS output folder** — every segment is sanitized, so an absolute path, a drive letter, or `..` can never send a clip outside it. Unknown tokens are left as-is, so a typo is visible instead of silently dropped.
+
+  > 💡 Upgrading from the old **Monthly subfolders** checkbox? A one-time **Migrate** button appears here and folds it into your template as `{game}/{yearmonth}` — your existing layout is preserved.
+
+### 🗂️ Organization
+
+  | Setting | Description |
+  |---------|-------------|
+  | Organize screenshots | Also sort screenshots |
+  | Organize recordings | Sort regular recordings (not just replays) |
+  | Scan all processes | Detect background games when alt-tabbed (Windows only) |
 
 ### 🛡️ Spam Protection
 
@@ -383,7 +396,7 @@
   │   └── Space Marine 2 - 2025-06-17 18-45-00.mp4
   │
   ├── 📁 Minecraft/
-  │   └── 2025-06/                    ← from a "{game}/{yearmonth}" template
+  │   └── 2025-06/                    ← From a {yearmonth} template
   │       └── Minecraft - 2025-06-18 11-22-33.mp4
   │
   └── 📁 Desktop/                     ← Fallback folder
@@ -503,11 +516,14 @@
 
 ## 📋 Changelog
 
-### v2.11.0 — 🧩 Folder Templates
+### v2.11.0 — 🧩 Folder Templates & 🏷️ Prefix = Folder Name
 
-- **🧩 Folder Templates** — The destination structure is now a template with tokens instead of a fixed `{game}` folder. Tokens: `{game}`, `{year}`, `{month}`, `{day}`, `{date}`, `{yearmonth}`, `{hour}`, `{min}`. Examples: `{game}/Replays`, `{game}/{yearmonth}`. Resolved relative to the OBS output folder, with every path segment sanitized so a template can never escape it (no absolute paths, no `..` traversal). The default `{game}` reproduces the previous behavior exactly.
-- **🔄 Monthly-Subfolder Migration** — The old "monthly subfolders (YYYY-MM)" checkbox is replaced by the `{yearmonth}` token. If you had it enabled, a one-time **Migrate** button folds it into your template as `{game}/{yearmonth}` and then hides itself — nothing changes silently, and existing folder layouts are preserved.
-- **🧹 Simpler Directory Creation** — Folder creation is now a single recursive `mkdir` that handles arbitrary template depth.
+- **🧩 Folder Templates** — The destination folder is now a **template** of `{tokens}` (`{game}`, `{year}`, `{month}`, `{day}`, `{date}`, `{yearmonth}`, `{hour}`, `{min}`) instead of a fixed `<game>` layout. The default `{game}` keeps the classic behavior; every path segment is sanitized so a template can never escape the OBS output folder. See [Folder Templates](#-folder-templates).
+- **📅 Monthly Subfolders → `{yearmonth}`** — The old *Monthly subfolders* checkbox is replaced by the `{yearmonth}` token. If you had it enabled, a one-time **Migrate** button folds it into your template as `{game}/{yearmonth}` and then disappears — existing layouts are preserved.
+- **🏷️ Prefix = Folder Name** — The game-name prefix added to filenames now matches the destination folder (custom mappings and database names included) instead of the raw process name. With a mapping `shadps4.exe > Bloodborne` you now get `Bloodborne - Replay.mp4`, and database games get their pretty name too (`Aliens vs Predator - Replay.mp4` instead of `avp - Replay.mp4`). No-folder mode (`/`) keeps its old behavior.
+- **🔍 Custom Mappings in Background Scan** — The **Scan all running processes** option now also matches your custom name mappings and internal alias names. Previously it only consulted the built-in database, so tabbed-out saves could land in the fallback folder even with a correct mapping ([Issue #28](https://github.com/SlonickLab/Smart-Replay-Mover/issues/28))
+- **🎮 Database +2** — Added **Arena Breakout: Infinite** (`UAGame.exe`) and **Chivalry 2** (`Chivalry2-Win64-Shipping.exe`); the Arena Breakout launcher joined the ignore list ([Issue #28](https://github.com/SlonickLab/Smart-Replay-Mover/issues/28))
+- **📖 Log Clarity** — The `Using cached game:` log line is now `Game folder:` — replay detection runs fresh on every save, and the old wording wrongly suggested a stale cache
 
 ### v2.10.0 — 🔌 Replay Buffer Pro Compatibility
 
@@ -557,6 +573,9 @@
 - **🖥️ Adaptive UI** — Windows-only settings (Scan Processes, Scale, Position, Update Checker) auto-hide on Linux.
 - **🎬 FFmpeg Thumbnails on Linux** — Proper shell quoting, path validation, and error logging for cross-platform FFmpeg support.
 
+<details>
+<summary>View older versions</summary>
+
 ### v2.8.2
 
 - **🔍 Background Game Detection** — Added an option to scan all running processes for a game if the active window isn't one. This serves as a smart fallback if you alt-tabbed to Discord or the desktop before saving a clip! (Feature request: @EndCod3r)
@@ -569,9 +588,6 @@
 - **🧵 Thread-Safe Notifications** — All notification calls now go through a safe queue processed exclusively on one thread, eliminating cross-thread Win32 GDI deadlocks
 - **⚡ Smart Skip** — On fast systems (NVMe/SSD), the intermediate "Saving..." is automatically skipped in favor of "Clip Saved" when save completes instantly
 - **🐛 Detection Fix** — Fixed double `detect_game()` call during replay buffer save that could cause wrong folder assignment
-
-<details>
-<summary>View older versions</summary>
 
 ### v2.8.0
 

--- a/Smart Replay Mover.lua
+++ b/Smart Replay Mover.lua
@@ -1,7 +1,7 @@
--- Smart Replay Mover v2.10.0
+-- Smart Replay Mover v2.11.0
 -- Simple, safe, and reliable replay buffer organizer for OBS
 -- ============================================================================
-local VERSION = "2.10.0"
+local VERSION = "2.11.0"
 local GITHUB_RAW_URL = "https://raw.githubusercontent.com/SlonickLab/Smart-Replay-Mover/main/Smart%20Replay%20Mover.lua"
 local GITHUB_RELEASES_URL = "https://github.com/SlonickLab/Smart-Replay-Mover/releases"
 --
@@ -32,6 +32,20 @@ local GITHUB_RELEASES_URL = "https://github.com/SlonickLab/Smart-Replay-Mover/re
 -- Plagiarism or removal of this notice violates the license terms.
 --
 -- ============================================================================
+-- CHANGELOG v2.11.0:
+--   - NEW: Folder templates. The destination structure is now a template with
+--         tokens instead of a fixed <game> folder. Tokens: {game} {year} {month}
+--         {day} {date} {yearmonth} {hour} {min}. Examples: "{game}/Replays" or
+--         "{game}/{yearmonth}". Resolved relative to the OBS output folder; each
+--         segment is sanitized so a template can never escape it (no absolute
+--         paths, no ".." traversal). Default "{game}" reproduces prior behavior
+--   - CHANGE: The "monthly subfolders (YYYY-MM)" checkbox is replaced by the
+--         {yearmonth} token. Users who had it enabled see a one-time "Migrate" button
+--         that folds it into their template as "{game}/{yearmonth}" and then hides
+--         itself for good. Nothing changes silently and existing layouts are preserved
+--   - Simplified directory creation to a single recursive mkdir (handles arbitrary
+--         template depth)
+
 -- CHANGELOG v2.10.0:
 --   - NEW: Replay Buffer Pro compatibility (github.com/JoshuaPotter/replay-buffer-pro).
 --         Replays now go through a deferred move queue: the script waits for RBP's
@@ -255,7 +269,8 @@ local CONFIG = {
     add_game_prefix = true,
     organize_screenshots = true,
     organize_recordings = true,
-    use_date_subfolders = false,
+    use_date_subfolders = false,  -- legacy; migrated into folder_template via UI button
+    folder_template = "{game}",
     fallback_folder = "Desktop",
     duplicate_cooldown = 5.0,
     delete_spam_files = true,
@@ -4003,6 +4018,42 @@ local function clean_folder_path(str)
     return str
 end
 
+-- Substitute {token} placeholders in a folder template (case-insensitive token
+-- names). Date pieces are resolved at move time. Unknown tokens are left literal
+-- so typos are visible instead of silently dropped.
+local function apply_folder_template(template, game)
+    local repl = {
+        game = game or "",
+        year = os.date("%Y"),
+        month = os.date("%m"),
+        day = os.date("%d"),
+        date = os.date("%Y-%m-%d"),
+        yearmonth = os.date("%Y-%m"),  -- matches old monthly-subfolder format
+        hour = os.date("%H"),
+        min = os.date("%M"),
+    }
+    return (string.gsub(template, "{(%w+)}", function(k)
+        local v = repl[string.lower(k)]
+        return v ~= nil and v or ("{" .. k .. "}")
+    end))
+end
+
+-- Force a RELATIVE, safe path: clean each segment, drop empties/".", and strip any
+-- leading/trailing separators or drive letters. Prevents absolute paths and ".."
+-- traversal so output can never escape the OBS output directory.
+local function sanitize_relative_path(str)
+    str = clean_folder_path(str)  -- strips <>:"|?* and .. , normalizes \ -> /
+    local segments = {}
+    for seg in string.gmatch(str, "[^/]+") do
+        seg = string.gsub(seg, "^%s+", "")
+        seg = string.gsub(seg, "%s+$", "")
+        if seg ~= "" and seg ~= "." then
+            table.insert(segments, seg)
+        end
+    end
+    return table.concat(segments, "/")
+end
+
 -- Recursive directory creation (Linux-safe: preserves leading "/" for absolute paths)
 local function recursive_mkdir(path)
     path = string.gsub(path, "\\", "/")
@@ -4897,8 +4948,19 @@ local function move_file(src, folder_name, game_name)
             real_folder = get_existing_folder(dir, safe_folder)
         end
         
-        local target_dir = dir .. "/" .. real_folder
+        -- Resolve the folder template into a relative structure, injecting the
+        -- resolved game folder as {game}. Sanitized to stay relative to the OBS
+        -- output dir. Defaults to "{game}" (unchanged behavior).
+        local template = (CONFIG.folder_template and CONFIG.folder_template ~= "")
+                         and CONFIG.folder_template or "{game}"
+        local rel = sanitize_relative_path(apply_folder_template(template, real_folder))
+        if rel == "" then rel = real_folder end  -- safety net if template resolves empty
 
+        local target_dir = dir .. "/" .. rel
+
+        -- Legacy monthly-subfolder support: applies only until the user migrates it
+        -- into the template (see the Migrate button in ORGANIZATION). After migration
+        -- this flag is false and the date comes from the {yearmonth} token instead.
         if CONFIG.use_date_subfolders then
             target_dir = target_dir .. "/" .. os.date("%Y-%m")
         end
@@ -4938,20 +5000,13 @@ local function move_file(src, folder_name, game_name)
             dbg("Truncated filename to: " .. new_filename)
         end
 
-        local base_folder = dir .. "/" .. real_folder
-        if not safe_mkdir(base_folder) then
-            log("ERROR: Failed to create folder: " .. base_folder)
+        -- Create the full target directory. safe_mkdir -> recursive_mkdir builds all
+        -- parent folders, so this covers arbitrary template depth (+ date subfolder).
+        if not safe_mkdir(target_dir) then
+            log("ERROR: Failed to create folder: " .. target_dir)
             return false
         end
-        dbg("Folder ready: " .. base_folder)
-
-        if CONFIG.use_date_subfolders then
-            if not safe_mkdir(target_dir) then
-                log("ERROR: Failed to create date subfolder: " .. target_dir)
-                return false
-            end
-            dbg("Date subfolder ready: " .. target_dir)
-        end
+        dbg("Folder ready: " .. target_dir)
 
         -- Collision-safe target name (avoid silent overwrite by MoveFileExW)
         target_path = uniquify_path(target_path)
@@ -5927,6 +5982,7 @@ local function read_config(settings)
     CONFIG.organize_screenshots = obs.obs_data_get_bool(settings, "organize_screenshots")
     CONFIG.organize_recordings = obs.obs_data_get_bool(settings, "organize_recordings")
     CONFIG.use_date_subfolders = obs.obs_data_get_bool(settings, "use_date_subfolders")
+    CONFIG.folder_template = obs.obs_data_get_string(settings, "folder_template")
     CONFIG.fallback_folder = obs.obs_data_get_string(settings, "fallback_folder")
     CONFIG.duplicate_cooldown = obs.obs_data_get_double(settings, "duplicate_cooldown")
     CONFIG.delete_spam_files = obs.obs_data_get_bool(settings, "delete_spam_files")
@@ -6190,6 +6246,52 @@ local function on_rbp_mode_changed(props, property, settings)
     return true -- refresh UI
 end
 
+-- ============================================================================
+-- Legacy monthly-subfolder migration (explicit, user-triggered)
+-- Older versions organized as <game>/[YYYY-MM] via the "monthly subfolders"
+-- checkbox (use_date_subfolders). Instead of migrating silently, we show a
+-- checkbox + button ONLY while that legacy flag is set. Clicking the button
+-- folds the effect into the folder template as {yearmonth} and clears the flag,
+-- after which the checkbox and button never appear again.
+-- ============================================================================
+local function migrate_legacy_date_setting(settings)
+    if not obs.obs_data_get_bool(settings, "use_date_subfolders") then
+        return false
+    end
+    local tmpl = obs.obs_data_get_string(settings, "folder_template")
+    if not tmpl or tmpl == "" then tmpl = "{game}" end
+    if not string.find(string.lower(tmpl), "{yearmonth}", 1, true) then
+        tmpl = tmpl .. "/{yearmonth}"
+        obs.obs_data_set_string(settings, "folder_template", tmpl)
+    end
+    obs.obs_data_set_bool(settings, "use_date_subfolders", false)
+    log("Migrated legacy monthly-subfolder setting into folder template: " .. tmpl)
+    return true
+end
+
+local function on_migrate_template_clicked(props, property)
+    local settings = STATE.script_settings
+    if not settings then return false end
+    if not migrate_legacy_date_setting(settings) then return false end
+    read_config(settings)  -- refresh CONFIG (updated template + cleared flag)
+
+    -- Hide the now-obsolete controls. obs_properties_get may not descend into
+    -- groups on all OBS versions, so fall back to the group's content.
+    local function hide(name)
+        local p = obs.obs_properties_get(props, name)
+        if not p then
+            local grp = obs.obs_properties_get(props, "folder_section")
+            local content = grp and obs.obs_property_group_content(grp)
+            p = content and obs.obs_properties_get(content, name)
+        end
+        if p then obs.obs_property_set_visible(p, false) end
+    end
+    hide("use_date_subfolders")
+    hide("migrate_info")
+    hide("migrate_template_btn")
+    return true  -- refresh UI (also updates the template textbox to show {yearmonth})
+end
+
 function script_properties()
     local props = obs.obs_properties_create()
 
@@ -6250,7 +6352,31 @@ function script_properties()
 
     -- ORGANIZATION GROUP
     local folder_group = obs.obs_properties_create()
-    obs.obs_properties_add_bool(folder_group, "use_date_subfolders", "📅  Create monthly subfolders (YYYY-MM)")
+    obs.obs_properties_add_text(folder_group, "folder_template", "🧩  Folder template", obs.OBS_TEXT_DEFAULT)
+    obs.obs_properties_add_text(folder_group, "folder_template_help",
+[[Builds subfolders under the OBS output folder.
+
+Tokens:
+   {game} — detected game folder
+   {year} {month} {day} — 2026 / 07 / 23
+   {date} — 2026-07-23
+   {yearmonth} — 2026-07  (old monthly folders)
+   {hour} {min} — clock time
+
+Examples:   {game}/Replays      {game}/{yearmonth}]],
+        obs.OBS_TEXT_INFO)
+    -- Legacy monthly-subfolder controls: only shown while the old flag is still set.
+    -- The Migrate button folds it into the template; both then disappear for good.
+    if CONFIG.use_date_subfolders then
+        obs.obs_properties_add_bool(folder_group, "use_date_subfolders", "📅  Monthly subfolders (legacy)")
+        obs.obs_properties_add_text(folder_group, "migrate_info",
+[[Legacy "monthly subfolders" is still on.
+Click Migrate to fold it into the template as {yearmonth}.
+One-time — this checkbox and button then disappear.]],
+            obs.OBS_TEXT_INFO)
+        obs.obs_properties_add_button(folder_group, "migrate_template_btn",
+            "⬆️  Migrate monthly-subfolders into template", on_migrate_template_clicked)
+    end
     obs.obs_properties_add_bool(folder_group, "organize_screenshots", "📸  Also organize screenshots")
     obs.obs_properties_add_bool(folder_group, "organize_recordings", "🎬  Organize recordings (Start/Stop Recording)")
     obs.obs_properties_add_bool(folder_group, "scan_all_processes", "🔍  Detect game by scanning all running processes")
@@ -6371,6 +6497,7 @@ function script_defaults(settings)
     obs.obs_data_set_default_bool(settings, "organize_screenshots", true)
     obs.obs_data_set_default_bool(settings, "organize_recordings", true)
     obs.obs_data_set_default_bool(settings, "use_date_subfolders", false)
+    obs.obs_data_set_default_string(settings, "folder_template", "{game}")
     obs.obs_data_set_default_string(settings, "fallback_folder", "Desktop")
     obs.obs_data_set_default_double(settings, "duplicate_cooldown", 5.0)
     obs.obs_data_set_default_bool(settings, "delete_spam_files", true)

--- a/Smart Replay Mover.lua
+++ b/Smart Replay Mover.lua
@@ -33,18 +33,21 @@ local GITHUB_RELEASES_URL = "https://github.com/SlonickLab/Smart-Replay-Mover/re
 --
 -- ============================================================================
 -- CHANGELOG v2.11.0:
---   - NEW: Folder templates. The destination structure is now a template with
---         tokens instead of a fixed <game> folder. Tokens: {game} {year} {month}
---         {day} {date} {yearmonth} {hour} {min}. Examples: "{game}/Replays" or
---         "{game}/{yearmonth}". Resolved relative to the OBS output folder; each
---         segment is sanitized so a template can never escape it (no absolute
---         paths, no ".." traversal). Default "{game}" reproduces prior behavior
---   - CHANGE: The "monthly subfolders (YYYY-MM)" checkbox is replaced by the
---         {yearmonth} token. Users who had it enabled see a one-time "Migrate" button
---         that folds it into their template as "{game}/{yearmonth}" and then hides
---         itself for good. Nothing changes silently and existing layouts are preserved
---   - Simplified directory creation to a single recursive mkdir (handles arbitrary
---         template depth)
+--   - NEW: Filename prefix now matches the destination folder name (custom mappings
+--         and database names included) instead of the raw process name — e.g.
+--         "Aliens vs Predator - Replay.mp4" instead of "avp - Replay.mp4"
+--   - NEW: "Scan all running processes" now also matches custom name mappings and
+--         alias names, not just the built-in database (Issue #28)
+--   - NEW: Arena Breakout Infinite (UAGame.exe) and Chivalry 2 added to the database;
+--         Arena Breakout launcher added to the ignore list
+--   - Log wording: "Using cached game:" -> "Game folder:" (replay detection is fresh
+--         on every save; the old text wrongly suggested a stale cache)
+--   - NEW: Folder templates. The destination folder is now a template of {tokens}
+--         instead of a fixed <game> layout: {game} {year} {month} {day} {date}
+--         {yearmonth} {hour} {min}. Default "{game}" keeps prior behavior; each
+--         segment is sanitized so a template can never escape the OBS output folder
+--   - CHANGE: the "monthly subfolders" checkbox is replaced by the {yearmonth} token;
+--         users who had it enabled get a one-time "Migrate" button that folds it in
 
 -- CHANGELOG v2.10.0:
 --   - NEW: Replay Buffer Pro compatibility (github.com/JoshuaPotter/replay-buffer-pro).
@@ -269,7 +272,7 @@ local CONFIG = {
     add_game_prefix = true,
     organize_screenshots = true,
     organize_recordings = true,
-    use_date_subfolders = false,  -- legacy; migrated into folder_template via UI button
+    use_date_subfolders = false,  -- legacy; replaced by folder_template
     folder_template = "{game}",
     fallback_folder = "Desktop",
     duplicate_cooldown = 5.0,
@@ -557,6 +560,7 @@ local GAME_DATABASE = {
     ["celebritypoker"] = "Poker Night at the Inventory",
     ["celeste"] = "Celeste",
     ["childoflight"] = "Child of Light",
+    ["chivalry2-win64-shipping"] = "Chivalry 2",
     ["chronicle"] = "Chronicle - Runescape Legends",
     ["cities"] = "Cities: Skylines",
     ["citra-qt"] = "Citra",
@@ -2059,6 +2063,7 @@ local GAME_DATABASE = {
     ["twinsector_steam"] = "Twin Sector",
     ["twwse"] = "The Whispered World Special Edition",
     ["tyranny"] = "Tyranny",
+    ["uagame"] = "Arena Breakout Infinite",
     ["udk"] = "Unreal Development Kit",
     ["udkgame"] = "Unmechanical",
     ["ue4-win64-shipping"] = "Unreal Tournament 4",
@@ -2554,6 +2559,9 @@ local IGNORE_LIST = {
 
     -- Amazon Games
     "amazongames", "primegaming", "amazongameslauncher",
+
+    -- Level Infinite / Tencent
+    "arenabreakoutlauncher",
 
     -- ═══════════════════════════════════════════════════════════════
     -- GAME LAUNCHERS - INDIE / OTHER (v2.7.0 New)
@@ -4018,37 +4026,27 @@ local function clean_folder_path(str)
     return str
 end
 
--- Substitute {token} placeholders in a folder template (case-insensitive token
--- names). Date pieces are resolved at move time. Unknown tokens are left literal
--- so typos are visible instead of silently dropped.
+-- Expand {token} placeholders (case-insensitive).
 local function apply_folder_template(template, game)
-    local repl = {
+    local t = {
         game = game or "",
-        year = os.date("%Y"),
-        month = os.date("%m"),
-        day = os.date("%d"),
-        date = os.date("%Y-%m-%d"),
-        yearmonth = os.date("%Y-%m"),  -- matches old monthly-subfolder format
-        hour = os.date("%H"),
-        min = os.date("%M"),
+        year = os.date("%Y"), month = os.date("%m"), day = os.date("%d"),
+        date = os.date("%Y-%m-%d"), yearmonth = os.date("%Y-%m"),
+        hour = os.date("%H"), min = os.date("%M"),
     }
-    return (string.gsub(template, "{(%w+)}", function(k)
-        local v = repl[string.lower(k)]
+    return (template:gsub("{(%w+)}", function(k)
+        local v = t[k:lower()]
         return v ~= nil and v or ("{" .. k .. "}")
     end))
 end
 
--- Force a RELATIVE, safe path: clean each segment, drop empties/".", and strip any
--- leading/trailing separators or drive letters. Prevents absolute paths and ".."
--- traversal so output can never escape the OBS output directory.
+-- Force a template to a relative path that stays inside the output folder.
 local function sanitize_relative_path(str)
-    str = clean_folder_path(str)  -- strips <>:"|?* and .. , normalizes \ -> /
     local segments = {}
-    for seg in string.gmatch(str, "[^/]+") do
-        seg = string.gsub(seg, "^%s+", "")
-        seg = string.gsub(seg, "%s+$", "")
-        if seg ~= "" and seg ~= "." then
-            table.insert(segments, seg)
+    for seg in clean_folder_path(str):gmatch("[^/]+") do
+        seg = seg:gsub("^%s+", ""):gsub("%s+$", "")
+        if seg ~= "" and seg ~= "." and seg ~= ".." then
+            segments[#segments + 1] = seg
         end
     end
     return table.concat(segments, "/")
@@ -4509,7 +4507,9 @@ local function get_background_game()
             local exe_file = ffi.string(pe32.szExeFile)
             local name = string.gsub(exe_file, "%.[eE][xX][eE]$", ""):lower()
             
-            if not is_ignored(name) and GAME_DATABASE and GAME_DATABASE[name] then
+            if not is_ignored(name) and ((CUSTOM_NAMES_EXACT and CUSTOM_NAMES_EXACT[name])
+                or (GAME_NAMES and GAME_NAMES[name])
+                or (GAME_DATABASE and GAME_DATABASE[name])) then
                 dbg("Background game found via process snapshot: " .. name)
                 kernel32.CloseHandle(snapshot)
                 return name
@@ -4948,19 +4948,14 @@ local function move_file(src, folder_name, game_name)
             real_folder = get_existing_folder(dir, safe_folder)
         end
         
-        -- Resolve the folder template into a relative structure, injecting the
-        -- resolved game folder as {game}. Sanitized to stay relative to the OBS
-        -- output dir. Defaults to "{game}" (unchanged behavior).
-        local template = (CONFIG.folder_template and CONFIG.folder_template ~= "")
+        -- Build the destination from the folder template; {game} is the detected folder.
+        local template = (CONFIG.folder_template ~= nil and CONFIG.folder_template ~= "")
                          and CONFIG.folder_template or "{game}"
         local rel = sanitize_relative_path(apply_folder_template(template, real_folder))
-        if rel == "" then rel = real_folder end  -- safety net if template resolves empty
-
+        if rel == "" then rel = real_folder end
         local target_dir = dir .. "/" .. rel
 
-        -- Legacy monthly-subfolder support: applies only until the user migrates it
-        -- into the template (see the Migrate button in ORGANIZATION). After migration
-        -- this flag is false and the date comes from the {yearmonth} token instead.
+        -- Legacy monthly subfolders (until the user migrates to {yearmonth}).
         if CONFIG.use_date_subfolders then
             target_dir = target_dir .. "/" .. os.date("%Y-%m")
         end
@@ -4974,10 +4969,11 @@ local function move_file(src, folder_name, game_name)
               ", will_add=" .. tostring(should_add_prefix))
 
         if should_add_prefix then
+            -- Prefix mirrors the actual destination folder (custom/DB name), not the raw process name
             -- For nested paths (e.g., "Singleplayer/DS3"), use only the last segment as prefix
-            local prefix_source = game_name
-            if string.find(game_name, "[/\\]") then
-                prefix_source = string.match(game_name, "([^/\\]+)$") or game_name
+            local prefix_source = real_folder
+            if string.find(prefix_source, "[/\\]") then
+                prefix_source = string.match(prefix_source, "([^/\\]+)$") or prefix_source
                 dbg("Nested path detected, using last segment for prefix: " .. prefix_source)
             end
             local safe_game = clean_filename(prefix_source)
@@ -5000,8 +4996,7 @@ local function move_file(src, folder_name, game_name)
             dbg("Truncated filename to: " .. new_filename)
         end
 
-        -- Create the full target directory. safe_mkdir -> recursive_mkdir builds all
-        -- parent folders, so this covers arbitrary template depth (+ date subfolder).
+        -- One recursive mkdir creates every level of the template path.
         if not safe_mkdir(target_dir) then
             log("ERROR: Failed to create folder: " .. target_dir)
             return false
@@ -5114,7 +5109,7 @@ local function process_file_with_game(path, folder_name, game_name)
         return process_file(path)
     end
 
-    log("Using cached game: " .. folder_name)
+    log("Game folder: " .. folder_name)
     return move_file(path, folder_name, game_name or folder_name)
 end
 
@@ -6246,41 +6241,30 @@ local function on_rbp_mode_changed(props, property, settings)
     return true -- refresh UI
 end
 
--- ============================================================================
--- Legacy monthly-subfolder migration (explicit, user-triggered)
--- Older versions organized as <game>/[YYYY-MM] via the "monthly subfolders"
--- checkbox (use_date_subfolders). Instead of migrating silently, we show a
--- checkbox + button ONLY while that legacy flag is set. Clicking the button
--- folds the effect into the folder template as {yearmonth} and clears the flag,
--- after which the checkbox and button never appear again.
--- ============================================================================
+-- Fold the legacy use_date_subfolders flag into the template as {yearmonth}.
 local function migrate_legacy_date_setting(settings)
-    if not obs.obs_data_get_bool(settings, "use_date_subfolders") then
-        return false
-    end
+    if not obs.obs_data_get_bool(settings, "use_date_subfolders") then return false end
     local tmpl = obs.obs_data_get_string(settings, "folder_template")
     if not tmpl or tmpl == "" then tmpl = "{game}" end
-    if not string.find(string.lower(tmpl), "{yearmonth}", 1, true) then
+    if not tmpl:lower():find("{yearmonth}", 1, true) then
         tmpl = tmpl .. "/{yearmonth}"
         obs.obs_data_set_string(settings, "folder_template", tmpl)
     end
     obs.obs_data_set_bool(settings, "use_date_subfolders", false)
-    log("Migrated legacy monthly-subfolder setting into folder template: " .. tmpl)
+    log("Migrated legacy monthly subfolders into folder template: " .. tmpl)
     return true
 end
 
 local function on_migrate_template_clicked(props, property)
     local settings = STATE.script_settings
-    if not settings then return false end
-    if not migrate_legacy_date_setting(settings) then return false end
-    read_config(settings)  -- refresh CONFIG (updated template + cleared flag)
+    if not settings or not migrate_legacy_date_setting(settings) then return false end
+    read_config(settings)
 
-    -- Hide the now-obsolete controls. obs_properties_get may not descend into
-    -- groups on all OBS versions, so fall back to the group's content.
+    -- obs_properties_get may not search inside groups on all versions.
     local function hide(name)
         local p = obs.obs_properties_get(props, name)
         if not p then
-            local grp = obs.obs_properties_get(props, "folder_section")
+            local grp = obs.obs_properties_get(props, "template_section")
             local content = grp and obs.obs_property_group_content(grp)
             p = content and obs.obs_properties_get(content, name)
         end
@@ -6289,7 +6273,7 @@ local function on_migrate_template_clicked(props, property)
     hide("use_date_subfolders")
     hide("migrate_info")
     hide("migrate_template_btn")
-    return true  -- refresh UI (also updates the template textbox to show {yearmonth})
+    return true
 end
 
 function script_properties()
@@ -6350,33 +6334,25 @@ function script_properties()
     obs.obs_property_set_visible(rbp_help_prop, rbp_visible)
     obs.obs_properties_add_group(props, "rbp_section", "🎬  REPLAY BUFFER PRO", obs.OBS_GROUP_NORMAL, rbp_group)
 
+    -- FOLDER TEMPLATES GROUP
+    local template_group = obs.obs_properties_create()
+    obs.obs_properties_add_text(template_group, "folder_template", "🧩  Folder template", obs.OBS_TEXT_DEFAULT)
+    obs.obs_properties_add_text(template_group, "folder_template_help",
+        "Tokens: {game} {year} {month} {day} {date} {yearmonth} {hour} {min}. Combine them with any separator; / makes a subfolder. E.g. {game}/{hour} - {min}. See README.",
+        obs.OBS_TEXT_INFO)
+    -- Show the legacy controls only while the old flag is set.
+    if CONFIG.use_date_subfolders then
+        obs.obs_properties_add_bool(template_group, "use_date_subfolders", "📅  Monthly subfolders (legacy)")
+        obs.obs_properties_add_text(template_group, "migrate_info",
+            "Legacy monthly subfolders is on. Migrate folds it into the template as {yearmonth} (one-time).",
+            obs.OBS_TEXT_INFO)
+        obs.obs_properties_add_button(template_group, "migrate_template_btn",
+            "⬆️  Migrate monthly subfolders into template", on_migrate_template_clicked)
+    end
+    obs.obs_properties_add_group(props, "template_section", "🧩  FOLDER TEMPLATES", obs.OBS_GROUP_NORMAL, template_group)
+
     -- ORGANIZATION GROUP
     local folder_group = obs.obs_properties_create()
-    obs.obs_properties_add_text(folder_group, "folder_template", "🧩  Folder template", obs.OBS_TEXT_DEFAULT)
-    obs.obs_properties_add_text(folder_group, "folder_template_help",
-[[Builds subfolders under the OBS output folder.
-
-Tokens:
-   {game} — detected game folder
-   {year} {month} {day} — 2026 / 07 / 23
-   {date} — 2026-07-23
-   {yearmonth} — 2026-07  (old monthly folders)
-   {hour} {min} — clock time
-
-Examples:   {game}/Replays      {game}/{yearmonth}]],
-        obs.OBS_TEXT_INFO)
-    -- Legacy monthly-subfolder controls: only shown while the old flag is still set.
-    -- The Migrate button folds it into the template; both then disappear for good.
-    if CONFIG.use_date_subfolders then
-        obs.obs_properties_add_bool(folder_group, "use_date_subfolders", "📅  Monthly subfolders (legacy)")
-        obs.obs_properties_add_text(folder_group, "migrate_info",
-[[Legacy "monthly subfolders" is still on.
-Click Migrate to fold it into the template as {yearmonth}.
-One-time — this checkbox and button then disappear.]],
-            obs.OBS_TEXT_INFO)
-        obs.obs_properties_add_button(folder_group, "migrate_template_btn",
-            "⬆️  Migrate monthly-subfolders into template", on_migrate_template_clicked)
-    end
     obs.obs_properties_add_bool(folder_group, "organize_screenshots", "📸  Also organize screenshots")
     obs.obs_properties_add_bool(folder_group, "organize_recordings", "🎬  Organize recordings (Start/Stop Recording)")
     obs.obs_properties_add_bool(folder_group, "scan_all_processes", "🔍  Detect game by scanning all running processes")
@@ -6691,7 +6667,7 @@ function script_unload()
 end
 
 -- ============================================================================
--- END OF SCRIPT v2.10.0
+-- END OF SCRIPT v2.11.0
 -- Copyright (C) 2025-2026 SlonickLab - Licensed under GPL v3
 -- https://github.com/SlonickLab/Smart-Replay-Mover
 -- ============================================================================


### PR DESCRIPTION
## 🧩 Folder Templates

Adds a **folder template** so clips can be organized into any structure you like, using tokens - instead of the fixed `<game>/[YYYY-MM]` layout.

The default template is `{game}`, which behaves exactly like today, so **existing setups are unaffected** unless the user opts in.

### Why

I wanted a subfolder inside each game folder (`{game}/Replays`) and there was no way to do it. Instead of adding yet another checkbox, I turned the whole path into a template so you can arrange it however you like:

- `{game}/Replays` — what I was after
- `{yearmonth}/{game}` — group by month first
- `{game}/{year}/{month}` — deeper date archiving

As a bonus, the old "monthly subfolders" checkbox collapses into the `{yearmonth}` token — so this removes UI instead of adding more.

### What's new

A Folder template field in the 🗂️ ORGANIZATION settings. Tokens are substituted at save time and the result becomes the destination folder (relative to the OBS output folder):

| Token | Expands to |
|-------|------------|
| `{game}` | Detected game folder (e.g. `Counter-Strike 2`) |
| `{year}` `{month}` `{day}` | `2026` / `07` / `23` |
| `{date}` | `2026-07-23` |
| `{yearmonth}` | `2026-07` |
| `{hour}` `{min}` | Clock time |

Examples: `{game}/Replays` → `Counter-Strike 2/Replays/` · `{game}/{yearmonth}` → `Counter-Strike 2/2026-07/`

<img width="581" height="419" alt="grafik" src="https://github.com/user-attachments/assets/0a7fd7cf-d6bc-4b7e-917d-90c3c8205b36" />

### Replaces the "monthly subfolders" checkbox - with a migration button

The old Create monthly subfolders (YYYY-MM) checkbox is superseded by the `{yearmonth}` token. Rather than migrating silently, users who had it enabled see a one-time Migrate button that folds it into their template as `{game}/{yearmonth}` and then disappears for good. Existing folder layouts are preserved.

<img width="566" height="580" alt="grafik" src="https://github.com/user-attachments/assets/bd0a6ac5-4625-478a-a151-0f8ade2ae118" />

### 🛡️ Safety

Templates are always resolved relative to the OBS output folder. Every path segment is sanitized (existing `clean_folder_path` + a new `sanitize_relative_path`), so a template can't produce an absolute path, a drive letter, or `..` traversal - clips can never escape the output directory.

### ♻️ Backwards compatibility

- Default template `{game}` = current behavior.
- Legacy `use_date_subfolders` keeps working until the user clicks Migrate (nothing changes silently).
- Directory creation simplified to a single recursive `mkdir` that handles arbitrary template depth.

### Testing

- Verified `{game}`, `{game}/Replays`, and `{game}/{yearmonth}` on Windows with OBS 32.1.2
- Verified the Migrate button appears only for upgrading users, folds in `{yearmonth}`, and disappears afterward.
- Verified malicious templates (`../../{game}`, `C:/x/{game}`) stay inside the output folder.

---

Version bumped to **2.11.0**; changelog added to the script header and the README.